### PR TITLE
docs: Grammar cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Finding duplicates is easy. Cleaning up the disk when there are thousands of the
 
 A Backdown session goes through the following phases:
 
-1. Backdown analyzes the directory of your choice and find sets of duplicates (files whose content is exactly the same). Backdown ignores symlinks and files or directories whose name starts with a dot.
+1. Backdown analyzes the directory of your choice and finds sets of duplicates (files whose content is exactly the same). Backdown ignores symlinks and files or directories whose name starts with a dot.
 2. Backdown asks you a few questions depending on the analysis. Nothing is removed at this point—you only stage files for removal. Backdown never lets you stage all items in a set of identical files.
 3. After optionally reviewing the list of staged files, you confirm the removals.
 4. Backdown does the removals on disk.
@@ -67,7 +67,7 @@ cargo install --locked backdown
 
 You must have the Rust env installed: https://rustup.rs
 
-Download this repository then run
+Download this repository, then run:
 
 ```bash
 cargo install --path .
@@ -143,5 +143,5 @@ The JSON looks like this:
 * If you launch backdown on a big directory, it may find more duplicates than you suspect. Don't force yourself to answer *all* questions at first—if you stage the removals from the first dozen questions, you'll already gain a lot and may do the others another day.
 * Don't launch backdown at the root of your disk because you don't want to deal with duplicates in system resources, programs, build artifacts, etc. Launch backdown where you store your images, videos, or music.
 * Backdown isn't designed for dev directories and doesn't respect `.gitignore` rules.
-* If you launch backdown in a directory with millions files on a slow disk, you'll have to wait a long time while the content is hashed. Try with a smaller directory first if you have an HDD.
+* If you launch backdown in a directory with millions of files on a slow disk, you'll have to wait a long time while the content is hashed. Try with a smaller directory first if you have an HDD.
 * If you're only interested in images, use the -i option.

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -27,7 +27,7 @@ pub struct DirPair<'d> {
     pub file_pairs: Vec<FilePair>,
 }
 
-/// a brotherhood gather duplicates having the same parent
+/// a brotherhood gathers duplicates having the same parent
 #[derive(Debug)]
 pub struct Brotherhood<'d> {
 
@@ -40,7 +40,7 @@ pub struct Brotherhood<'d> {
 
     /// when all files have names like "thing (copy).png", "thing (another copy).png", etc.
     /// except one file, we can propose an automated resolution.
-    /// Note that we don't check the start of filenames are identical because we
+    /// Note that we don't check that the start of filenames are identical because we
     /// don't, in fact, care.
     pub is_auto_solvable: bool,
 }

--- a/src/dup.rs
+++ b/src/dup.rs
@@ -71,7 +71,7 @@ impl DupFileRef {
                 |n| n.to_string_lossy().to_string()
             )
     }
-    /// get the file name when the file has a name like "thing (3).jpg"
+    /// get the filename when the file has a name like "thing (3).jpg"
     /// or "thing (3rd copy).png"
     pub fn copy_name(self, dups:&[DupSet]) -> Option<&str> {
         copy_name(self.path(dups))
@@ -83,7 +83,7 @@ impl DupFileRef {
     }
 }
 
-/// get the name if this path is of a "copy" file, that is an usual name for a copy
+/// get the name if this path is of a "copy" file, that is a usual name for a copy
 pub fn copy_name(path: &Path) -> Option<&str> {
     path
         .file_name()

--- a/src/json.rs
+++ b/src/json.rs
@@ -32,7 +32,7 @@ fn available_path(name: &str) -> PathBuf {
 }
 
 /// write a JSON value in a file whose name will be based on the provided
-/// name, with a date and if necessary with an additional number to avoid
+/// name, with a date and, if necessary, with an additional number to avoid
 /// collision.
 pub fn write_in_file(
     name: &str,

--- a/src/removal_report.rs
+++ b/src/removal_report.rs
@@ -131,11 +131,11 @@ impl<'d> RemovalReport<'d> {
         }
     }
 
-    /// "Normally" the algorithms of backdown never remove all files
+    /// "Normally", the algorithms of backdown never remove all files
     /// in a set of identical files. But if I change those algorithms
     /// and make them more complex, I may make an error. So this
-    /// function will check there's at least one kept file in each
-    /// touched set, and will raise an error if a set is totally
+    /// function will check that there's at least one kept file in
+    /// each touched set, and will raise an error if a set is totally
     /// emptied.
     /// This *must* be called just before starting the real removals.
     pub fn check_no_emptied_set(


### PR DESCRIPTION
I missed something in README last time; this includes a fix for that, as well as minor grammatical fixes in the code comments.